### PR TITLE
Change root logger level

### DIFF
--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -26,7 +26,7 @@
             <AppenderRef ref="RollingFile"/>
         </Logger>
 
-        <Root level="info">
+        <Root level="error">
             <AppenderRef ref="Console"/>
         </Root>
     </Loggers>


### PR DESCRIPTION
- change root logger level from info to error to prevent having info logs of third party libraries wherever the catalog-client is used as a dependency.