### PR TITLE
Revert log level of catalog-client + uploadArchives issue description

### DIFF
--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -19,7 +19,7 @@
     </Appenders>
 
     <Loggers>
-        <Logger name="org.ow2.proactive.catalogclient" level="warn" additivity="false">
+        <Logger name="org.ow2.proactive.catalogclient" level="info" additivity="false">
             <AppenderRef ref="RollingFile"/>
         </Logger>
 


### PR DESCRIPTION
Final attempt to fix uploadArchives. The issue was that the name of the artifact pushed to the nexus was not the correct one. Locally, the produced artifact was catalog-client-xxxx.jar but when built on the docker slave, this artifact would be named Linux-slave-xxxx.jar and no catalog-client artifact would be updated in the end. The solution for this issue is to set explicitely the name that is used to produce the artifact in the gradle file. In this case we set in build.gradle the line "archivesBaseName = 'catalog-client'". Then all produced artifacts, on all machine are named catalog-client-xxx.jar, which fixes the issue.