### PR TITLE
FIX: use correct spring framework version number

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -113,7 +113,7 @@ if(hasProperty('target') && target == 'android') {
 ext {
     swagger_annotations_version = "1.5.15"
     jackson_version = "2.8.9"
-    spring_web_version = "4.3.9.RELEASE"
+    spring_web_version = "4.2.5.RELEASE"
     jodatime_version = "2.9.9"
     junit_version = "4.12"
 }


### PR DESCRIPTION
Fix a conflict caused by the fact that a different sprint-framework version number was used here. We align it with the same version in all other projects
`4.2.5.RELEASE` instead of `4.3.9.RELEASE`